### PR TITLE
adding init block to plugin to load at runtime

### DIFF
--- a/plugins/agentlibrary/AgentLibrary.html
+++ b/plugins/agentlibrary/AgentLibrary.html
@@ -1,5 +1,3 @@
-<h2>Agent Library</h2>
-<h4>Meet the agents available under your license</h4>
 <div class="profile-heading-container">
     <div class="body">
         <strong class="profile-heading">Select an Agent</strong>
@@ -23,6 +21,12 @@
         <ul id="agent-protocols"></ul>
     </div>
 </li>
+
+<div id="init-plugin">
+    <script>
+        console.log('Initializing AgentLibrary plugin')
+    </script>
+</div>
 
 <script>
     $(document).ready(function () {

--- a/plugins/agentlibrary/AgentLibrary.html
+++ b/plugins/agentlibrary/AgentLibrary.html
@@ -1,5 +1,3 @@
-<meta name="version" content="1">
-
 <h2>Agent Library</h2>
 <h4>Meet the agents available under your license</h4>
 <div class="profile-heading-container">

--- a/plugins/agentlibrary/config.yml
+++ b/plugins/agentlibrary/config.yml
@@ -1,3 +1,3 @@
 name: AgentLibrary
 description: Manage agents available in your license
-version: 1
+version: a328ed3b2b1663f315b0e40bff50864c


### PR DESCRIPTION
This should be merged with 0.9.7 because the name/description are included with plugins by default starting in that version.

The init-plugin block runs actions when Operator first boots, so you can hook in plugin effects immediately and/or when the plugin is clicked into.