### PR TITLE
Cloud plugin: Redirector support and pre-implanted hosts

### DIFF
--- a/plugins/cloud/Cloud.html
+++ b/plugins/cloud/Cloud.html
@@ -1,0 +1,232 @@
+<div class="profile-heading-container">
+    <div class="body">
+        <strong class="profile-heading">Cloud resources</strong>
+        <p>
+            Deploy either new redirectors, to accept beacons over the internet, or new compromised servers, to build
+            a custom test range and execute attacks on various operating systems.
+        </p>
+    </div>
+</div>
+
+<div id="cloud-div" class="loader-container">
+    <div class="label-text">
+        <p>Purpose</p>
+        <select id="cloud-provider">
+            <option value="aws">Amazon Web Services (AWS)</option>
+            <option value="gcp">Google Cloud Platform (GCP)</option>
+        </select>
+    </div>
+    <div id="aws">
+        <div class="label-text">
+            <p>Purpose</p>
+            <select id="aws-platform">
+                <option value="gateway">Linux redirector</option>
+                <option value="windows">Compromised Windows server</option>
+                <option value="linux">Compromised Linux server</option>
+                <option value="darwin">Compromised Mac OS server</option>
+            </select>
+        </div>
+        <div id="range-configs" style="display: none">
+            <div id="agents" class="label-text">
+                <p>Drop agent</p>
+                <select id="select-agent">
+                    <option id="pneuma" value="pneuma">Drop a Pneuma agent</option>
+                </select>
+            </div>
+            <div id="redirectors" class="label-text">
+                <p>Redirector</p>
+                <select id="select-redirector"></select>
+            </div>
+        </div>
+        <div class="label-text">
+            <p>AWS access key</p>
+            <div class="input-wrapper"><input id="aws-access-key" type="password" spellcheck="false"/></div>
+        </div>
+        <div class="label-text">
+            <p>AWS secret key</p>
+            <div class="input-wrapper"><input id="aws-secret-key" type="password" spellcheck="false"/></div>
+        </div>
+        <div class="label-text">
+            <p>Private key path</p>
+            <div class="input-wrapper"><input id="aws-key" type="text" spellcheck="false" placeholder=""/></div>
+        </div>
+        <button id="aws-deploy" onclick="deployAWS()">Deploy</button>
+    </div>
+    <div id="gcp" style="display: none;">
+        <div class="label-text">
+            <p>Purpose</p>
+            <select id="gcp-platform">
+                <option value="gateway">Linux redirector</option>
+            </select>
+        </div>
+        <div class="label-text">
+            <p>Project ID</p>
+            <div class="input-wrapper"><input id="project" type="text" spellcheck="false"/></div>
+        </div>
+        <div class="label-text">
+            <p>Service account</p>
+            <div class="input-wrapper"><input id="user_id" type="text" spellcheck="false"/></div>
+        </div>
+        <div class="label-text">
+            <p>Service account key file path</p>
+            <div class="input-wrapper"><input id="rsa_key" type="text" spellcheck="false"/></div>
+        </div>
+        <div class="label-text">
+            <p>Project-wide SSH user</p>
+            <div class="input-wrapper"><input id="ssh_user" type="text" spellcheck="false"/></div>
+        </div>
+        <div class="label-text">
+            <p>Project-wide SSH key file path</p>
+            <div class="input-wrapper"><input id="ssh_key" type="text" spellcheck="false"/></div>
+        </div>
+        <button id="gcp-deploy" onclick="deployGCP()">Deploy</button>
+    </div>
+    <div class="loader"></div>
+</div>
+
+<div id="init-plugin">
+    <script>
+        $(document).ready(function () {
+            let config = getPluginConfig('Cloud')
+            Object.keys(config.redirectors ? config.redirectors : {}).forEach(host => {
+                REDIRECTORS[host] = config.redirectors[host]
+            })
+        })
+    </script>
+</div>
+<script>
+    $(document).ready(function () {
+        refreshPage()
+
+        $('#cloud-provider').on('change', (ev) => {
+            Array.from(ev.target).forEach(opt => $('#' + opt.value).hide())
+            $('#' + ev.target.value).show()
+        })
+
+        $('#aws-platform').on('change', function(ev) {
+            if(ev.target.value==='gateway'){
+                $('#range-configs').hide()
+            } else {
+                $('#range-configs').show()
+            }
+        })
+    })
+
+    function refreshPage(){
+        const config = getPluginConfig('Cloud')
+        $('#aws-key').val(config.aws?.key_name || '')
+        $('#aws-access-key').val(config.aws?.access_key_id || '')
+        $('#aws-secret-key').val(config.aws?.secret_access_key || '')
+        setGCPElems(config)
+        Object.keys(REDIRECTORS).forEach(host => {
+            $('#select-redirector').append(`<option value="${host}">${host}</option>`)
+        })
+    }
+
+    function setGCPElems(config) {
+        const gcp = $('#gcp')
+        gcp.find('#user_id').val(config.gcp?.user_id || '')
+        gcp.find('#project').val(config.gcp?.project || '')
+        gcp.find('#rsa_key').val(config.gcp?.rsa_key || '')
+        gcp.find('#ssh_user').val(config.gcp?.ssh_user || '')
+        gcp.find('#ssh_key').val(config.gcp?.ssh_key || '')
+    }
+
+    function deployAWS(){
+        $("#cloud-div .loader").addClass("loading")
+        let config = getPluginConfig('Cloud')
+
+        function rangeSuccess(d){
+            $("#cloud-div .loader").removeClass("loading")
+            showNotification('Deployed!', d.instance + ' may take several minutes to show up')
+        }
+        function tunnelSuccess(d){
+            $("#cloud-div .loader").removeClass("loading")
+            const redirector = {
+                user: 'ec2-user',
+                key: config.aws.key_name
+            }
+            REDIRECTORS[d.instance] = redirector
+            if(!config.hasOwnProperty('redirectors')) {
+                config['redirectors'] = {}
+            }
+            config.redirectors[d.instance] = redirector
+            flushPluginConfig('Cloud', config)
+            showNotification('Success!', 'Your redirector is now available')
+            refreshPage()
+        }
+        function failure(d){
+            $("#cloud-div .loader").removeClass("loading")
+            showNotification('Failed', d.responseText)
+        }
+        config['aws'] = {
+            key_name: $('#aws-key').val(),
+            access_key_id: $('#aws-access-key').val(),
+            secret_access_key: $('#aws-secret-key').val()
+        }
+        flushPluginConfig('Cloud', config)
+        let request = {
+            token: SETTINGS.account.token,
+            email: SETTINGS.account.email,
+            agent: $('#select-agent option:selected').val(),
+            platform: $('#aws-platform').val(),
+            callback: $('#select-redirector option:selected').val()+':'+SETTINGS.local.tcp_port,
+            config: {
+                key_name: config.aws.key_name.split('/').slice(-1)[0],
+                access_key_id: config.aws.access_key_id,
+                secret_access_key: config.aws.secret_access_key
+            }
+        }
+        const uri = $('#aws-platform').val() === 'gateway' ? '/range/aws/gateway' : '/range/aws'
+        const success = $('#aws-platform').val() === 'gateway' ? tunnelSuccess : rangeSuccess
+        restRequest('POST', request, success, failure, uri)
+    }
+
+    function deployGCP() {
+        $("#cloud-div .loader").addClass("loading")
+        let config = getPluginConfig('Cloud')
+
+        function tunnelSuccess(d){
+            $("#cloud-div .loader").removeClass("loading")
+            const redirector = {
+                user: config.gcp.ssh_user,
+                key: config.gcp.ssh_key
+            }
+            REDIRECTORS[d.instance] = redirector
+            if(!config.hasOwnProperty('redirectors')) {
+                config['redirectors'] = {}
+            }
+            config.redirectors[d.instance] = redirector
+            flushPluginConfig('Cloud', config)
+            showNotification('Success!', 'Your redirector is now available')
+            refreshPage()
+        }
+
+        function failure(d){
+            $("#cloud-div .loader").removeClass("loading")
+            showNotification('Failed', d.responseText)
+        }
+
+        const gcp = $('#gcp')
+        config['gcp'] = {
+            user_id: gcp.find('#user_id').val(),
+            project: gcp.find('#project').val(),
+            ssh_user: gcp.find('#ssh_user').val(),
+            ssh_key: gcp.find('#ssh_key').val(),
+            rsa_key: gcp.find('#rsa_key').val()
+        }
+        flushPluginConfig('Cloud', config)
+        let request = {
+            token: SETTINGS.account.token,
+            email: SETTINGS.account.email,
+            config: {
+                user_id: config.gcp.user_id,
+                project: config.gcp.project,
+                key_name: config.gcp.ssh_key,
+                rsa_key: JSON.parse(loadData(config.gcp.rsa_key))['private_key']
+            }
+        }
+        const uri = '/range/gcp/gateway'
+        restRequest('POST', request, tunnelSuccess, failure, uri)
+    }
+</script>

--- a/plugins/cloud/config.yml
+++ b/plugins/cloud/config.yml
@@ -1,4 +1,4 @@
 name: Cloud
 description: Deploy redirectors and test ranges
-version: undetermined
-license: professional
+version: db3ec040e20dfc657dab510aeab74759
+license: community

--- a/plugins/cloud/config.yml
+++ b/plugins/cloud/config.yml
@@ -1,0 +1,4 @@
+name: Cloud
+description: Deploy redirectors and test ranges
+version: undetermined
+license: professional


### PR DESCRIPTION
- Moved cloud support into a dedicated plugin
- Leverages new cloud-provider agnostic back-end to enable easier support of new cloud providers
- Adds support for deploying redirectors on GCP
- Adds support for deploying redirectors on AWS
- Adds support for deploying pre-compromised linux, windows, and mac instances on AWS