### PR TITLE
adding .exe extension to windows payloads

### DIFF
--- a/plugins/agentlibrary/AgentLibrary.html
+++ b/plugins/agentlibrary/AgentLibrary.html
@@ -34,7 +34,7 @@
             const describe = a.package ? 'Download by clicking a platform below' : 'Built into Operator and requires no download'
             template.find('#agent-description').text(describe)
             template.find('#agent-platforms').append(a.platforms.map(p => a.package
-                ? $(`<a href="#" onClick="downloadFile('https://s3.amazonaws.com/operator.payloads/${a.package}/${a.package}-${p}', '${a.package}-${p}')">${p}</a>`)
+                ? $(`<a href="#" onClick="downloadFile('https://s3.amazonaws.com/operator.payloads/${a.package}/${a.package}-${p}', '${a.package}-${p == 'windows' ? `${p}.exe` : p}')">${p}</a>`)
                 : $(`<span>${p}</span>`)))
             template.find('#agent-name .aux').append(a.protocols.map(p => $(`<span>${p}</span>`)))
             template.show()


### PR DESCRIPTION
re: https://github.com/preludeorg/operator-support/issues/41, @khyberspache i know you said to patch on the gatekeeper side to include .exe in the -o, but even then we'd still need to append the .exe extension here as well, which (even though i don't have a windows box to test on) should work as a minimal change on its own.