### PR TITLE
Using path.basename to split aws key names

### DIFF
--- a/plugins/cloud/Cloud.html
+++ b/plugins/cloud/Cloud.html
@@ -172,7 +172,7 @@
             platform: $('#aws-platform').val(),
             callback: $('#select-redirector option:selected').val()+':'+SETTINGS.local.tcp_port,
             config: {
-                key_name: config.aws.key_name.split('/').slice(-1)[0],
+                key_name: path.basename(config.aws.key_name),
                 access_key_id: config.aws.access_key_id,
                 secret_access_key: config.aws.secret_access_key
             }

--- a/plugins/cloud/config.yml
+++ b/plugins/cloud/config.yml
@@ -1,4 +1,4 @@
 name: Cloud
 description: Deploy redirectors and test ranges
-version: db3ec040e20dfc657dab510aeab74759
+version: 0e3facb17089d4cb52824698db3a7e78
 license: community


### PR DESCRIPTION
re: https://github.com/preludeorg/operator-support/issues/96