### PR TITLE
removing config files from plugins

### DIFF
--- a/plugins/agentlibrary/config.yml
+++ b/plugins/agentlibrary/config.yml
@@ -1,3 +1,0 @@
-name: AgentLibrary
-description: Manage agents available in your license
-version: 816e7aa347bacc74b442eb27d93b2232

--- a/plugins/art/config.yml
+++ b/plugins/art/config.yml
@@ -1,4 +1,0 @@
-name: ART
-description: Import Atomic Red Team attack files
-version: 8122c8e3e5fa09d610f6ceb206d5eae8
-background: https://www.summitpartners.com/system/uploads/article/phase_2_image/262/4.30.2019_-_Red_Canary_-_News_Image.jpg

--- a/plugins/cloud/config.yml
+++ b/plugins/cloud/config.yml
@@ -1,4 +1,0 @@
-name: Cloud
-description: Deploy redirectors and test ranges
-version: f4bf6aac6d267b9f899a70a1a6409058
-license: community

--- a/plugins/navigator/config.yml
+++ b/plugins/navigator/config.yml
@@ -1,3 +1,0 @@
-name: Navigator
-description: Display the ATT&CK Navigator and export layers
-version: 96ffd9826f7e460f98bce8d1b7502c13 

--- a/plugins/themechange/config.yml
+++ b/plugins/themechange/config.yml
@@ -1,3 +1,0 @@
-name: ThemeChange
-description: Change the Operator theme
-version: 79d505c7fc32e8ada29f0e11cf9a187f

--- a/plugins/toolbox/config.yml
+++ b/plugins/toolbox/config.yml
@@ -1,5 +1,0 @@
-name: Toolbox
-description: Manage your red team tools and utilities
-version: db06eaa927f283562e6f6280a914c9c3
-background: >-
-  https://st2.depositphotos.com/42774578/42425/i/450/depositphotos_424257142-stock-photo-dark-gray-sledge-hammer-black.jpg

--- a/upgrade-patch-0.9.17.ps1
+++ b/upgrade-patch-0.9.17.ps1
@@ -1,3 +1,0 @@
-Rename-Item $env:APPDATA\Operator\workspace $env:APPDATA\Operator\login.prelude.org;
-mv $env:APPDATA\Operator\settings.yml $env:APPDATA\Operator\login.prelude.org;
-mv $env:APPDATA\Operator\schedules.yml $env:APPDATA\Operator\login.prelude.org;


### PR DESCRIPTION
Why remove? These configs are not read in anywhere (i.e., we don't pull directly from here) and the versions can be misleading, as a) they're manually generated and b) they're not in sync with what people will have in their app