### PR TITLE
Fixed importing ART tests

### DIFF
--- a/plugins/ART/ART.html
+++ b/plugins/ART/ART.html
@@ -92,9 +92,11 @@
               command: escapeTtpCommand(executor, ttp.executor.command ? ttp.executor.command : ttp.executor.steps)
             };
           });
-          Object.keys(ttp.input_arguments).forEach(arg => {
-            ART_FACTS[arg] = ttp.input_arguments[arg].default;
-          });
+          if ("input_arguments" in ttp) {
+            Object.keys(ttp.input_arguments).forEach(arg => {
+              ART_FACTS[arg] = ttp.input_arguments[arg].default;
+            });
+          }
           procedures.push(atk);
         });
         resolve(procedures);

--- a/plugins/ART/ART.html
+++ b/plugins/ART/ART.html
@@ -127,7 +127,8 @@
       "cmd": [new RegExp(`[\\^&]\\s*$`)],
       "sh": [new RegExp(`^#(?!{)`), new RegExp(`[\\\\;]\\s*$`), new RegExp(`\\bthen\\s*$`)],
       "bash": [new RegExp(`^#(?!{)`), new RegExp(`[\\\\;]\\s*$`), new RegExp(`\\bthen\\s*$`)],
-      "python": []
+      "python": [],
+      "manual": []
     };
     command = command.replaceAll(/#{([a-zA-Z0-9_\.\|]+)}/g, "#{art.$1}");
     return command.trim().split('\n').reduce((acc, part, idx) => {

--- a/plugins/ART/ART.html
+++ b/plugins/ART/ART.html
@@ -92,11 +92,9 @@
               command: escapeTtpCommand(executor, ttp.executor.command ? ttp.executor.command : ttp.executor.steps)
             };
           });
-          if ("input_arguments" in ttp) {
-            Object.keys(ttp.input_arguments).forEach(arg => {
-              ART_FACTS[arg] = ttp.input_arguments[arg].default;
-            });
-          }
+          Object.keys(ttp?.input_arguments || {}).forEach(arg => {
+            ART_FACTS[arg] = ttp.input_arguments[arg].default;
+          });
           procedures.push(atk);
         });
         resolve(procedures);


### PR DESCRIPTION
This PR fixes two issues with importing ART files:
- Files with 1 or more tests missing the `input_arguments` field would fail to import the whole file
- Files with 1 or more `manual` executors would fail to import the whole file