### PR TITLE
hiding internal tools

### DIFF
--- a/plugins/Cloud/Cloud.html
+++ b/plugins/Cloud/Cloud.html
@@ -471,7 +471,7 @@
                 $('#aws #elastic-agent-configs').hide();
             }
 
-            const tools = ($('#aws-platform').find(':selected').data('config').tools || []).map(tool =>
+            const tools = ($('#aws-platform').find(':selected').data('config').tools || []).filter(tool => !tool.internal).map(tool =>
                 $(`<div id="aws-tool-${tool.tool}" class="label-text" data-tool="${tool.tool}">
                     <p style="font-family: PF Din Mono; font-size: 11px; font-weight: 600 !important; line-height: 24px; text-transform: uppercase; letter-spacing: 2px;">${tool.title}</p>
                     <span style="display: block; color: #999; font-size: 14px; font-weight: 100; margin: 0 0 5px;">${tool.description}</span>


### PR DESCRIPTION
hiding internal tools so we don't overwhelm users with too many extra options (even if we provided descriptions, this seems a lot cleaner)

re: https://github.com/preludeorg/operator/issues/1559

depends on: https://github.com/preludeorg/gatekeeper/pull/866