### PR TITLE
'Click here to load it' now indicates pointer cursor

### DIFF
--- a/plugins/Navigator/Navigator.html
+++ b/plugins/Navigator/Navigator.html
@@ -4,7 +4,7 @@
         <p>This plugin acts as a connector to <a href="https://github.com/mitre-attack/attack-navigator">MITRE's ATT&CK Navigator</a>.The principal feature of the Navigator is the ability for users to define layers - custom views of the ATT&CK knowledge base - e.g. showing just those techniques for a particular platform or highlighting techniques a specific adversary has been known to use. Layers can be created interactively within the Navigator or generated programmatically and then visualized via the Navigator. </p>
     </div>
     <br>
-    <p class="profile-heading" >Want to convert an existing layer file into an Operator adversary? <u><a onclick="document.querySelector('#file').click()">Click here to load it.</a></u></p>
+    <p class="profile-heading" >Want to convert an existing layer file into an Operator adversary? <span style="cursor:pointer"><u><a onclick="document.querySelector('#file').click()">Click here to load it.</a></u></span></p>
 </div>
 <select id="navigation-adversary">
     <option>Choose an adversary</option>


### PR DESCRIPTION
Re: #1762

'Click here to load it' within navigator plugin now highlights a pointer cursor to indicate clickable function.

@privateducky 